### PR TITLE
Расширена основа реакт приложения, добавлена "Auto Observable" обвязка для redux состояния

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { GlobalAppRouter } from './providers/app-router';
 import { Provider } from 'react-redux';
 import { useApp } from 'shared/hooks/use-app';
 import { useAuth } from 'shared/hooks/use-auth';
+import { BrowserRouter } from 'react-router-dom';
 
 export const App: RC = () => {
     const app = useApp();
@@ -14,7 +15,9 @@ export const App: RC = () => {
     return (
         <Provider store={app.getReduxStore()}>
             <Suspense fallback={<PageLoader />}>
-                <GlobalAppRouter />
+                <BrowserRouter>
+                    <GlobalAppRouter />
+                </BrowserRouter>
             </Suspense>
         </Provider>
     );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,9 +1,21 @@
 import './styles/index.scss';
-import { classNames } from 'shared/lib/class-names';
 import { type RC } from 'shared/types/component';
+import { Suspense } from 'react';
+import { PageLoader } from 'widgets/page-loader';
+import { GlobalAppRouter } from './providers/app-router';
+import { Provider } from 'react-redux';
+import { useApp } from 'shared/hooks/use-app';
+import { useAuth } from 'shared/hooks/use-auth';
 
 export const App: RC = () => {
+    const app = useApp();
+    useAuth();
+
     return (
-        <div className={classNames('app')}></div>
+        <Provider store={app.getReduxStore()}>
+            <Suspense fallback={<PageLoader />}>
+                <GlobalAppRouter />
+            </Suspense>
+        </Provider>
     );
 };

--- a/src/app/providers/app-router/index.ts
+++ b/src/app/providers/app-router/index.ts
@@ -1,1 +1,2 @@
-export { AppRouter } from './ui/app-router';
+export { GlobalAppRouter } from './ui/global-app-router';
+export { PartialAppRouter } from './ui/app-router';

--- a/src/app/providers/app-router/ui/app-router.tsx
+++ b/src/app/providers/app-router/ui/app-router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import c from './app-router.module.scss';
 import type { RouteConfig } from 'app/providers/app-router/config';
 import { type RC } from 'shared/types/component';
@@ -7,19 +7,17 @@ interface Props {
     routeConfig: RouteConfig
 }
 
-export const AppRouter: RC<Props> = ({ routeConfig }) => {
+export const PartialAppRouter: RC<Props> = ({ routeConfig }) => {
     return (
-        <BrowserRouter>
-            <Routes>
-                {Object.values(routeConfig).map(({ element, path }) => (
-                    <Route
-                        key={path}
-                        path={path}
-                        element={<div className={c.pageWrapper}>{element}</div>}
-                    />
-                ))}
-                <Route path="/*" element={<Navigate to="/" />} />
-            </Routes>
-        </BrowserRouter>
+        <Routes>
+            {Object.values(routeConfig).map(({ element, path }) => (
+                <Route
+                    key={path}
+                    path={path}
+                    element={<div className={c.pageWrapper}>{element}</div>}
+                />
+            ))}
+            <Route path="/*" element={<Navigate to="/" />} />
+        </Routes>
     );
 };

--- a/src/app/providers/app-router/ui/global-app-router.tsx
+++ b/src/app/providers/app-router/ui/global-app-router.tsx
@@ -1,0 +1,28 @@
+import { type RC } from 'shared/types/component';
+import { PartialAppRouter } from './app-router';
+import { privateRouteConfig, publicRouteConfig } from '../config';
+import { PageLoader } from 'widgets/page-loader';
+import { AuthStatus } from 'models/user';
+import { useObservableState } from 'repositories/redux/hooks/useTypedSelector';
+import { BrowserRouter } from 'react-router-dom';
+import { useApp } from 'shared/hooks/use-app';
+
+export const GlobalAppRouter: RC = () => {
+    const app = useApp();
+    const authStatus = useObservableState(() => app.user.getAuthStatus());
+
+    if (authStatus === AuthStatus.Pending) {
+        return <PageLoader />;
+    }
+
+    return (
+        <BrowserRouter>
+            <PartialAppRouter routeConfig={publicRouteConfig} />
+            {authStatus === AuthStatus.SignedIn
+                ? (
+                    <PartialAppRouter routeConfig={privateRouteConfig} />
+                )
+                : undefined}
+        </BrowserRouter>
+    );
+};

--- a/src/app/providers/app-router/ui/global-app-router.tsx
+++ b/src/app/providers/app-router/ui/global-app-router.tsx
@@ -4,7 +4,6 @@ import { privateRouteConfig, publicRouteConfig } from '../config';
 import { PageLoader } from 'widgets/page-loader';
 import { AuthStatus } from 'models/user';
 import { useObservableState } from 'repositories/redux/hooks/useTypedSelector';
-import { BrowserRouter } from 'react-router-dom';
 import { useApp } from 'shared/hooks/use-app';
 
 export const GlobalAppRouter: RC = () => {
@@ -13,16 +12,14 @@ export const GlobalAppRouter: RC = () => {
 
     if (authStatus === AuthStatus.Pending) {
         return <PageLoader />;
+    } else if (authStatus === AuthStatus.SignedIn) {
+        return (
+            <>
+                <PartialAppRouter routeConfig={publicRouteConfig} />
+                <PartialAppRouter routeConfig={privateRouteConfig} />
+            </>
+        );
+    } else {
+        return <PartialAppRouter routeConfig={publicRouteConfig} />;
     }
-
-    return (
-        <BrowserRouter>
-            <PartialAppRouter routeConfig={publicRouteConfig} />
-            {authStatus === AuthStatus.SignedIn
-                ? (
-                    <PartialAppRouter routeConfig={privateRouteConfig} />
-                )
-                : undefined}
-        </BrowserRouter>
-    );
 };

--- a/src/app/providers/error-boundary/index.ts
+++ b/src/app/providers/error-boundary/index.ts
@@ -1,0 +1,5 @@
+import { ErrorBoundary } from './ui/error-boundary';
+
+export {
+    ErrorBoundary
+};

--- a/src/app/providers/error-boundary/ui/error-boundary.tsx
+++ b/src/app/providers/error-boundary/ui/error-boundary.tsx
@@ -1,0 +1,34 @@
+import React, { type ErrorInfo } from 'react';
+import { PageError } from 'widgets/page-error';
+
+interface Props {
+    children: React.ReactNode
+}
+
+interface State {
+    hasError: boolean
+    info: string
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+    constructor (props: Props) {
+        super(props);
+        this.state = { hasError: false, info: '' };
+    }
+
+    static getDerivedStateFromError (): any {
+        return { hasError: true };
+    }
+
+    componentDidCatch (error: Error, errorInfo: ErrorInfo): void {
+        this.setState({ hasError: true, info: error.message });
+    }
+
+    render (): React.ReactNode {
+        if (this.state.hasError) {
+            return <PageError info={this.state.info}/>;
+        } else {
+            return this.props.children;
+        }
+    }
+}

--- a/src/features/application/index.ts
+++ b/src/features/application/index.ts
@@ -11,7 +11,6 @@ export class Application {
     #firebaseApi: FirebaseApi;
     #lsApi: LSApi;
 
-    // inputs
     postCardList: PostCardListModel;
     user: UserModel;
 
@@ -32,5 +31,9 @@ export class Application {
             api: process.env.DB === 'LS' ? this.#lsApi : this.#firebaseApi,
             storeApi: this.#reduxStoreApi
         });
+    }
+
+    getReduxStore (): ReduxStoreApi {
+        return this.#reduxStoreApi;
     }
 }

--- a/src/features/user/user.ts
+++ b/src/features/user/user.ts
@@ -38,6 +38,6 @@ export class UserFeature implements UserModel {
     }
 
     getAuthStatus (): AuthStatus {
-        return this.#storeApiService.getLoginStatus();
+        return this.#storeApiService.getAuthStatus();
     }
 }

--- a/src/features/user/user.ts
+++ b/src/features/user/user.ts
@@ -1,4 +1,4 @@
-import { type User, type UserModel } from 'models/user';
+import { type AuthStatus, type User, type UserModel } from 'models/user';
 import { type UserStoreApiService, type UserApiService } from 'services/user';
 
 export interface Dependencies {
@@ -35,5 +35,9 @@ export class UserFeature implements UserModel {
 
     getUser (): User {
         return this.#storeApiService.getUser();
+    }
+
+    getAuthStatus (): AuthStatus {
+        return this.#storeApiService.getLoginStatus();
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { App } from 'app/app';
+import { ErrorBoundary } from 'app/providers/error-boundary';
 import { Application } from 'features/application';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -9,6 +10,8 @@ global.window.app = new Application();
 
 root.render(
     <React.StrictMode>
-        <App />
+        <ErrorBoundary>
+            <App />
+        </ErrorBoundary>
     </React.StrictMode>
 );

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,14 +3,16 @@ export interface User {
     email: string
 }
 
-export enum LoginStatus {
+export enum AuthStatus {
     Pending = 'Pending',
-    LoggedIn = 'LoggedIn',
-    LoggedOut = 'LoggedOut',
+    SignedIn = 'SignedIn',
+    SignedOut = 'SignedOut',
 }
 
 export interface UserModel {
     signedUp: (email: string, password: string) => Promise<void>
     signedIn: (email: string, password: string) => Promise<void>
     signedOut: () => Promise<void>
+    getUser: () => User
+    getAuthStatus: () => AuthStatus
 };

--- a/src/repositories/redux/hooks/useTypedSelector.ts
+++ b/src/repositories/redux/hooks/useTypedSelector.ts
@@ -1,0 +1,5 @@
+import { useSelector } from 'react-redux';
+
+export const useObservableState = <TSelected>(state: () => TSelected): TSelected => {
+    return useSelector(() => state());
+};

--- a/src/repositories/redux/index.ts
+++ b/src/repositories/redux/index.ts
@@ -8,7 +8,6 @@ const rootReducer = combineReducers({
     [postCardListSlice.reducerPath]: postCardListSlice.reducer
 });
 
-// Слишком сложный тип, он должен выводиться автоматически
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const setupStore = () => {
     return configureStore({
@@ -19,7 +18,6 @@ export const setupStore = () => {
     });
 };
 
-// Автоматический вывод типа
 export type ReduxStoreApi = ReturnType<typeof setupStore>;
 
 export abstract class ReduxApiRepository extends ApiRepository {

--- a/src/repositories/user/store-api/api.ts
+++ b/src/repositories/user/store-api/api.ts
@@ -1,5 +1,5 @@
 import { userSignedIn, userSignedOut, userSignedUp, userSignsIn, userSignsUp } from './store-slice';
-import { type User } from 'models/user';
+import { type AuthStatus, type User } from 'models/user';
 import { ReduxApiRepository } from 'repositories/redux';
 import { type UserStoreApiRepository } from '../types';
 
@@ -30,5 +30,9 @@ export class ReduxUserStoreApiRepository extends ReduxApiRepository implements U
 
     public getUser (): User {
         return this.api.getState().userReducer.user;
+    }
+
+    public getLoginStatus (): AuthStatus {
+        return this.api.getState().userReducer.authStatus;
     }
 }

--- a/src/repositories/user/store-api/api.ts
+++ b/src/repositories/user/store-api/api.ts
@@ -32,7 +32,7 @@ export class ReduxUserStoreApiRepository extends ReduxApiRepository implements U
         return this.api.getState().userReducer.user;
     }
 
-    public getLoginStatus (): AuthStatus {
+    public getAuthStatus (): AuthStatus {
         return this.api.getState().userReducer.authStatus;
     }
 }

--- a/src/repositories/user/store-api/store-slice.ts
+++ b/src/repositories/user/store-api/store-slice.ts
@@ -1,9 +1,9 @@
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
-import { LoginStatus, type User } from 'models/user';
+import { AuthStatus, type User } from 'models/user';
 
 interface UserState {
     user: User
-    loginStatus: LoginStatus
+    authStatus: AuthStatus
 }
 
 const initialState: UserState = {
@@ -11,7 +11,7 @@ const initialState: UserState = {
         id: '',
         email: ''
     },
-    loginStatus: LoginStatus.Pending
+    authStatus: AuthStatus.Pending
 };
 
 export const userSlice = createSlice({
@@ -19,25 +19,25 @@ export const userSlice = createSlice({
     initialState,
     reducers: {
         userSignsUp (state) {
-            state.loginStatus = LoginStatus.Pending;
+            state.authStatus = AuthStatus.Pending;
         },
         userSignedUp (state, action: PayloadAction<User>) {
             state.user = action.payload;
-            state.loginStatus = LoginStatus.LoggedIn;
+            state.authStatus = AuthStatus.SignedIn;
         },
         userSignsIn (state) {
-            state.loginStatus = LoginStatus.Pending;
+            state.authStatus = AuthStatus.Pending;
         },
         userSignedIn (state, action: PayloadAction<User>) {
             state.user = action.payload;
-            state.loginStatus = LoginStatus.LoggedIn;
+            state.authStatus = AuthStatus.SignedIn;
         },
         userSignsOut (state) {
-            state.loginStatus = LoginStatus.Pending;
+            state.authStatus = AuthStatus.Pending;
         },
         userSignedOut (state) {
             state = initialState;
-            state.loginStatus = LoginStatus.LoggedOut;
+            state.authStatus = AuthStatus.SignedOut;
         }
     }
 });

--- a/src/repositories/user/types.ts
+++ b/src/repositories/user/types.ts
@@ -15,5 +15,5 @@ export interface UserStoreApiRepository extends ApiRepository {
     userSignsOut: () => void
     userSignedOut: () => void
     getUser: () => User
-    getLoginStatus: () => AuthStatus
+    getAuthStatus: () => AuthStatus
 };

--- a/src/repositories/user/types.ts
+++ b/src/repositories/user/types.ts
@@ -1,4 +1,4 @@
-import { type User } from 'models/user';
+import { type AuthStatus, type User } from 'models/user';
 import { type ApiRepository } from 'repositories/types';
 
 export interface UserApiRepository extends ApiRepository {
@@ -15,4 +15,5 @@ export interface UserStoreApiRepository extends ApiRepository {
     userSignsOut: () => void
     userSignedOut: () => void
     getUser: () => User
+    getLoginStatus: () => AuthStatus
 };

--- a/src/services/user/store-api.ts
+++ b/src/services/user/store-api.ts
@@ -33,7 +33,7 @@ export class UserStoreApiService extends ApiService {
         return this.apiRepository.getUser();
     }
 
-    public getLoginStatus (): AuthStatus {
-        return this.apiRepository.getLoginStatus();
+    public getAuthStatus (): AuthStatus {
+        return this.apiRepository.getAuthStatus();
     }
 }

--- a/src/services/user/store-api.ts
+++ b/src/services/user/store-api.ts
@@ -1,4 +1,4 @@
-import { type User } from 'models/user';
+import { type AuthStatus, type User } from 'models/user';
 import { type UserStoreApiRepository } from 'repositories/user';
 import { ApiService } from 'services/types';
 
@@ -31,5 +31,9 @@ export class UserStoreApiService extends ApiService {
 
     public getUser (): User {
         return this.apiRepository.getUser();
+    }
+
+    public getLoginStatus (): AuthStatus {
+        return this.apiRepository.getLoginStatus();
     }
 }

--- a/src/shared/hooks/use-app.ts
+++ b/src/shared/hooks/use-app.ts
@@ -1,0 +1,6 @@
+import { type Application } from 'features/application';
+
+// TODO не знаю стоит ли использовать тут нейминг хука, планируется использование только в компонентах реакта, но других хуков в нем не используется
+export function useApp (): Application {
+    return global.window.app;
+};

--- a/src/shared/hooks/use-auth.ts
+++ b/src/shared/hooks/use-auth.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { useApp } from './use-app';
+
+export function useAuth (): void {
+    const app = useApp();
+
+    useEffect(() => {
+        // TODO проверка токена
+        void app.user.signedIn('1234', '123');
+    }, []);
+};

--- a/src/shared/ui/button/button.tsx
+++ b/src/shared/ui/button/button.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import cls from './button.module.scss';
+import { classNames } from 'shared/lib/class-names';
+import { type RC } from 'shared/types/component';
+
+export enum ButtonTheme {
+    Clear = 'clear',
+    Default = 'default'
+}
+
+interface ButtonProps {
+    className?: string
+    theme?: ButtonTheme
+    children?: React.ReactNode
+    onClick: () => void
+}
+
+export const Button: RC<ButtonProps> = props => {
+    const {
+        className,
+        children,
+        theme,
+        onClick
+    } = props;
+
+    return (
+        <button
+            className={classNames([cls[theme], cls.button, className])}
+            onClick={onClick}
+        >
+            {children}
+        </button>
+    );
+};

--- a/src/shared/ui/loader/loader.tsx
+++ b/src/shared/ui/loader/loader.tsx
@@ -1,0 +1,20 @@
+import { type FC } from 'react';
+import c from './loader.module.scss';
+import { classNames } from 'shared/lib/class-names';
+
+interface LoaderProps {
+    className?: string
+}
+
+export const Loader: FC<LoaderProps> = ({ className }) => {
+    return (
+        <div
+            className={classNames([c.loader, className])}
+        >
+            <div></div>
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+    );
+};

--- a/src/widgets/page-error/index.ts
+++ b/src/widgets/page-error/index.ts
@@ -1,0 +1,5 @@
+import { PageError } from './ui/page-error';
+
+export {
+    PageError
+};

--- a/src/widgets/page-error/ui/page-error.tsx
+++ b/src/widgets/page-error/ui/page-error.tsx
@@ -1,0 +1,25 @@
+import { Button } from 'shared/ui/button/button';
+import c from './page-error.module.scss';
+import { classNames } from 'shared/lib/class-names';
+import { type RC } from 'shared/types/component';
+
+interface Props {
+    info: string
+}
+
+export const PageError: RC<Props> = ({ info }) => {
+    const reloadPage = (): void => {
+        location.reload();
+    };
+
+    // TODO оформить
+    return (
+        <div
+            className={classNames([c.pageError])}
+        >
+            <p>400 ☹️</p>
+            <p>{info}</p>
+            <Button onClick={reloadPage}>Обновить</Button>
+        </div>
+    );
+};

--- a/src/widgets/page-loader/index.ts
+++ b/src/widgets/page-loader/index.ts
@@ -1,0 +1,5 @@
+import { PageLoader } from './ui/page-loader';
+
+export {
+    PageLoader
+};

--- a/src/widgets/page-loader/ui/page-loader.tsx
+++ b/src/widgets/page-loader/ui/page-loader.tsx
@@ -1,0 +1,18 @@
+import { Loader } from 'shared/ui/loader/loader';
+import c from './page-loader.module.scss';
+import { type RC } from 'shared/types/component';
+import { classNames } from 'shared/lib/class-names';
+
+interface PageLoaderProps {
+    className?: string
+}
+
+export const PageLoader: RC<PageLoaderProps> = ({ className }) => {
+    return (
+        <div
+            className={classNames([c.pageLoader, className])}
+        >
+            <Loader/>
+        </div>
+    );
+};


### PR DESCRIPTION
### Что сделано

- Расширена основа для реакт приложения:
  - Добавлен провайдер ErrorBoundary
  - Добавлен Suspense
  - Создан компонент GlobalAppRouter, объединяющий все роутеры и содержащий логику по их подключению
- Для получения эффекта "Auto Observable" для стейта redux подключена библиотека react-redux
  - Добавлен провайдер стора
  - Создан кастомный хук useObservableState, который принимает функцию селектор стейта и делает ее следящей за изменением состояния. Это позволяет не использовать в самом редаксе хуки. Селекторы его состояния становится доступным для любого окружения, а для использования с реакт необходимо обернуть селектор в хук.
- Создан кастомный хук useApp
- Создан кастомный хук useAuth
- Созданы ui компоненты Button, Loader
- Созданы виджеты PageError, PageLoader

### Чек-лист

- [x] ПР имеет четкое **название**, короткое и описывающее его суть.
- [x] ПР имеет четкое **описание** того, что в рамках него было сделано.
- [x] Я провел **само-ревью** ПРа. Там нет кода, который я забыл удалить, случайно закоммитил и т.п.
- [x] ПР не содержит кода, который не соответствует цели ПРа.
- [x] ПР не содержит мерж конфликтов.
